### PR TITLE
Potential fix for code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^5.1.0",
-    "sqlite3": "^5.1.7"
+    "sqlite3": "^5.1.7",
+    "express-rate-limit": "^8.1.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -2,10 +2,18 @@ const express = require("express");
 const fs = require("fs");
 const sqlite3 = require("sqlite3").verbose();
 const path = require("path");
+const rateLimit = require("express-rate-limit");
 
 const app = express();
 const PORT = 3000;
 
+// Apply a rate limit to all requests
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100                  // limit each IP to 100 requests per windowMs
+});
+
+app.use(limiter);
 app.use(express.json());
 app.use(express.static(__dirname));
 


### PR DESCRIPTION
Potential fix for [https://github.com/userzfr/StockProtec/security/code-scanning/3](https://github.com/userzfr/StockProtec/security/code-scanning/3)

The ideal fix is to add a rate limiting middleware (such as `express-rate-limit`) to the relevant routes. Since the vulnerability is present on `/categories.json`, and other routes also access the database or filesystem, it is best practice to apply rate limiting globally (using `app.use()`) for all routes, or at least to all "expensive" routes, including `/categories.json`.

The fix involves:
- Installing and requiring the `express-rate-limit` package near the top.
- Creating a rate limiter instance with appropriate settings (for example, allowing 100 requests per 15 minutes from a single IP).
- Applying this middleware globally with `app.use(limiter);` before declaring the route handlers.

This requires adding a require statement for `express-rate-limit` and three lines to create and apply the limiter at the top of `server.js`.

Edits needed:
- Add `const rateLimit = require('express-rate-limit');` near the imports.
- Configure and define a limiter before any route handler or static middleware.
- Insert `app.use(limiter);` after creating the limiter, before the routes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
