### PR TITLE
Potential fix for code scanning alert no. 4: Exposure of private files

### DIFF
--- a/server.js
+++ b/server.js
@@ -15,7 +15,7 @@ const limiter = rateLimit({
 
 app.use(limiter);
 app.use(express.json());
-app.use(express.static(__dirname));
+app.use(express.static(path.join(__dirname, "public")));
 
 const DB_PATH = path.join(__dirname, "donnees.db");
 const db = new sqlite3.Database(DB_PATH);


### PR DESCRIPTION
Potential fix for [https://github.com/userzfr/StockProtec/security/code-scanning/4](https://github.com/userzfr/StockProtec/security/code-scanning/4)

The best fix is to serve static files only from a dedicated, non-root directory, typically called `public` (or similar), which contains only files meant to be exposed to the web.  

**General steps:**
- Move all client-facing static assets (HTML, CSS, JS, images) to a new subdirectory, e.g., `public`.
- Replace `app.use(express.static(__dirname));` with `app.use(express.static(path.join(__dirname, "public")));`

**Required updates:**
- In `server.js`, change line 18 to serve only the `public` directory.
- If the `public` directory does not exist, it should be created and populated with appropriate assets, but based only on the code shown, this is a code change only.

No other parts of the code seem to reference static files directly, so this single change suffices.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
