### PR TITLE
Potential fix for code scanning alert no. 50: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "sonner": "2.0.3",
     "tailwind-merge": "3.2.0",
     "tw-animate-css": "1.3.8",
-    "vaul": "1.1.2"
+    "vaul": "1.1.2",
+    "express-rate-limit": "^8.3.2"
   },
   "devDependencies": {
     "@tailwindcss/vite": "4.1.12",

--- a/server/server.js
+++ b/server/server.js
@@ -2,6 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import rateLimit from 'express-rate-limit';
 import db, { initializeDatabase } from './database.js';
 import { seedDatabase } from './seed.js';
 
@@ -13,6 +14,13 @@ const __dirname = path.dirname(__filename);
 
 // Middleware
 app.use(cors());
+
+const spaFallbackLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per window
+  standardHeaders: true,
+  legacyHeaders: false
+});
 app.use(express.json());
 
 // Initialiser la base de données au démarrage
@@ -772,7 +780,7 @@ app.get('/api/health', (req, res) => {
 
 // Serve static files (frontend build)
 app.use(express.static(path.join(__dirname, '..', 'dist')));
-app.use((req, res) => {
+app.use(spaFallbackLimiter, (req, res) => {
   res.sendFile(path.join(__dirname, '..', 'dist', 'index.html'));
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/userzfr/StockProtec/security/code-scanning/50](https://github.com/userzfr/StockProtec/security/code-scanning/50)

Add a rate-limiting middleware and apply it to the fallback route that serves `index.html` (and optionally static files) so repeated high-frequency requests are throttled before filesystem access.

Best minimal fix in `server/server.js`:
1. Add import for `express-rate-limit`.
2. Define a limiter instance near other middleware setup.
3. Attach limiter to the catch-all handler at line 775 by passing it as middleware before the handler function.

This preserves existing behavior for normal traffic while mitigating abuse. No route logic changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
