### PR TITLE
Potential fix for code scanning alert no. 35: DOM text reinterpreted as HTML

### DIFF
--- a/src/app/components/SimpleBarcodeDialog.tsx
+++ b/src/app/components/SimpleBarcodeDialog.tsx
@@ -21,49 +21,75 @@ export function SimpleBarcodeDialog({ barcode, title, open, onOpenChange }: Simp
     const printWindow = window.open('', '', 'width=800,height=600');
     if (!printWindow) return;
 
-    printWindow.document.write(`
-      <html>
-        <head>
-          <title>Impression - ${title}</title>
-          <style>
-            @media print {
-              @page {
-                size: A4;
-                margin: 1cm;
-              }
-              body {
-                margin: 0;
-                padding: 20px;
-                font-family: Arial, sans-serif;
-              }
-              .barcode-section {
-                text-align: center;
-                padding: 20px;
-                border: 2px solid #000;
-              }
-              h1 {
-                font-size: 24px;
-                margin-bottom: 20px;
-              }
-              svg {
-                max-width: 100%;
-                height: auto;
-              }
-            }
-          </style>
-        </head>
-        <body>
-          ${printContent.innerHTML}
-          <script>
-            window.onload = function() {
-              window.print();
-              window.close();
-            };
-          </script>
-        </body>
-      </html>
-    `);
-    printWindow.document.close();
+    const doc = printWindow.document;
+    doc.open();
+
+    const html = doc.createElement('html');
+    const head = doc.createElement('head');
+    const titleElement = doc.createElement('title');
+    titleElement.textContent = `Impression - ${title}`;
+
+    const style = doc.createElement('style');
+    style.textContent = `
+      @media print {
+        @page {
+          size: A4;
+          margin: 1cm;
+        }
+        body {
+          margin: 0;
+          padding: 20px;
+          font-family: Arial, sans-serif;
+        }
+        .barcode-section {
+          text-align: center;
+          padding: 20px;
+          border: 2px solid #000;
+        }
+        h1 {
+          font-size: 24px;
+          margin-bottom: 20px;
+        }
+        svg {
+          max-width: 100%;
+          height: auto;
+        }
+      }
+    `;
+
+    head.appendChild(titleElement);
+    head.appendChild(style);
+
+    const body = doc.createElement('body');
+    const section = doc.createElement('div');
+    section.className = 'barcode-section';
+
+    const heading = doc.createElement('h1');
+    heading.textContent = title;
+    section.appendChild(heading);
+
+    const barcodeWrapper = doc.createElement('div');
+    const svg = printContent.querySelector('svg');
+    if (svg) {
+      barcodeWrapper.appendChild(svg.cloneNode(true));
+    }
+    section.appendChild(barcodeWrapper);
+
+    body.appendChild(section);
+
+    const script = doc.createElement('script');
+    script.textContent = `
+      window.onload = function() {
+        window.print();
+        window.close();
+      };
+    `;
+    body.appendChild(script);
+
+    html.appendChild(head);
+    html.appendChild(body);
+    doc.replaceChild(html, doc.documentElement);
+    doc.close();
   };
 
   return (


### PR DESCRIPTION
Potential fix for [https://github.com/userzfr/StockProtec/security/code-scanning/35](https://github.com/userzfr/StockProtec/security/code-scanning/35)

The safest fix is to **stop writing HTML strings** that include tainted values and to **avoid reusing `innerHTML`**.  
Best approach here (without changing functionality): build the print window DOM using safe DOM APIs (`createElement`, `textContent`, `appendChild`) and clone only the barcode SVG node, rather than injecting raw HTML.

In `src/app/components/SimpleBarcodeDialog.tsx`, update `handlePrint`:

- Replace `document.write(\`...\`)` block entirely.
- Create `<html>`, `<head>`, `<title>`, `<style>`, `<body>` nodes programmatically.
- Set title via `textContent` (safe escaping).
- Create a print container and heading via `textContent`.
- Find barcode `<svg>` inside `printRef.current` and append a cloned node.
- Append a script element with static content for print/close behavior.
- Close document as before.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
