### PR TITLE
Potential fix for code scanning alert no. 49: Missing rate limiting

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -759,8 +759,16 @@ app.post('/api/categories', (req, res) => {
   }
 });
 
+// Limiteur de débit pour les suppressions de catégories
+const deleteCategoryLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 50, // max 50 suppressions par fenêtre et par IP
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
 // Supprimer une catégorie personnalisée
-app.delete('/api/categories/:id', (req, res) => {
+app.delete('/api/categories/:id', deleteCategoryLimiter, (req, res) => {
   try {
     const stmt = db.prepare('DELETE FROM custom_categories WHERE id = ?');
     stmt.run(req.params.id);


### PR DESCRIPTION
Potential fix for [https://github.com/userzfr/StockProtec/security/code-scanning/49](https://github.com/userzfr/StockProtec/security/code-scanning/49)

To fix this safely without changing endpoint behavior, apply a dedicated rate-limiting middleware to the DELETE route that performs the DB delete.  
Best approach in this file: define a small `deleteCategoryLimiter` with `express-rate-limit` near the route definitions, then attach it as middleware in `app.delete('/api/categories/:id', deleteCategoryLimiter, (req, res) => { ... })`.

This keeps existing functionality (same SQL, same response contract) while adding throttling protection specifically where CodeQL reported the issue.  
Changes needed in `server/server.js` (within shown region):
- Add a limiter definition before the DELETE route.
- Update the DELETE route signature to include the limiter middleware.
- No new imports required (the file already imports `rateLimit`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
