### PR TITLE
Potential fix for code scanning alert no. 85: DOM text reinterpreted as HTML

### DIFF
--- a/src/app/components/SimpleBarcodeDialog.tsx
+++ b/src/app/components/SimpleBarcodeDialog.tsx
@@ -23,58 +23,69 @@ export function SimpleBarcodeDialog({ barcode, title, open, onOpenChange }: Simp
 
     const doc = printWindow.document;
     doc.open();
+    doc.write('<!DOCTYPE html><html><head></head><body></body></html>');
+    doc.close();
 
     const svg = printContent.querySelector('svg');
     const barcodeSvg = svg ? svg.cloneNode(true) : null;
-    const printHtml = `
-      <!DOCTYPE html>
-      <html>
-        <head>
-          <title>Impression - ${title}</title>
-          <style>
-            @media print {
-              @page {
-                size: A4;
-                margin: 1cm;
-              }
-              body {
-                margin: 0;
-                padding: 20px;
-                font-family: Arial, sans-serif;
-              }
-              .barcode-section {
-                text-align: center;
-                padding: 20px;
-                border: 2px solid #000;
-              }
-              h1 {
-                font-size: 24px;
-                margin-bottom: 20px;
-              }
-              svg {
-                max-width: 100%;
-                height: auto;
-              }
-            }
-          </style>
-        </head>
-        <body>
-          <div class="barcode-section">
-            <h1>${title}</h1>
-            ${barcodeSvg ? new XMLSerializer().serializeToString(barcodeSvg as Node) : ''}
-          </div>
-          <script>
-            window.onload = function() {
-              window.print();
-              window.close();
-            };
-          </script>
-        </body>
-      </html>
-    `;
 
-    doc.write(printHtml);
-    doc.close();
+    const head = doc.head;
+    const body = doc.body;
+
+    const titleEl = doc.createElement('title');
+    titleEl.textContent = `Impression - ${title}`;
+    head.appendChild(titleEl);
+
+    const styleEl = doc.createElement('style');
+    styleEl.textContent = `
+      @media print {
+        @page {
+          size: A4;
+          margin: 1cm;
+        }
+        body {
+          margin: 0;
+          padding: 20px;
+          font-family: Arial, sans-serif;
+        }
+        .barcode-section {
+          text-align: center;
+          padding: 20px;
+          border: 2px solid #000;
+        }
+        h1 {
+          font-size: 24px;
+          margin-bottom: 20px;
+        }
+        svg {
+          max-width: 100%;
+          height: auto;
+        }
+      }
+    `;
+    head.appendChild(styleEl);
+
+    const section = doc.createElement('div');
+    section.className = 'barcode-section';
+
+    const heading = doc.createElement('h1');
+    heading.textContent = title;
+    section.appendChild(heading);
+
+    if (barcodeSvg) {
+      section.appendChild(barcodeSvg);
+    }
+
+    body.appendChild(section);
+
+    const scriptEl = doc.createElement('script');
+    scriptEl.textContent = `
+      window.onload = function() {
+        window.print();
+        window.close();
+      };
+    `;
+    body.appendChild(scriptEl);
   };
 
   return (


### PR DESCRIPTION
Potential fix for [https://github.com/userzfr/StockProtec/security/code-scanning/85](https://github.com/userzfr/StockProtec/security/code-scanning/85)

The safest fix without changing functionality is to stop injecting `title` into an HTML string and instead build the print document with DOM APIs (`createElement`, `textContent`, `appendChild`). `textContent` ensures user input is treated as text, not HTML. Keep the existing print styling and behavior, and still append the cloned barcode SVG node directly.

**Changes to make (single file):**
- **File:** `src/app/components/SimpleBarcodeDialog.tsx`
- **Region:** inside `handlePrint`, replace the `printHtml` template literal + `doc.write(printHtml)` flow.
- Build `<html>`, `<head>`, `<title>`, `<style>`, `<body>`, container `<div>`, and `<h1>` using DOM methods.
- Set dynamic title text with `textContent`.
- Append cloned SVG node as a node (not serialized string interpolation).
- Add onload print/close behavior via script element text (static script is fine) or by assigning `printWindow.onload`.

No new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
